### PR TITLE
make sure the legacy user handles incorrect username and emails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dev/migrate: ##@dev Run migration container to create realm
 .PHONY: dev/build
 dev/build: ##@dev Build keycloak image to run extension
 	@echo "Building docker image"
-	(cd docker && $(COMPOSE) build)
+	(cd docker && $(COMPOSE) build --no-cache)
 	@echo "Completed..."
 
 .PHONY: dev/run

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUser.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUser.java
@@ -34,7 +34,7 @@ public class LegacyUser {
     }
 
     public void setUsername(String username) {
-        this.username = username;
+        this.username = toLowerCaseSafe(username);
     }
 
     public String getEmail() {
@@ -42,7 +42,7 @@ public class LegacyUser {
     }
 
     public void setEmail(String email) {
-        this.email = email;
+        this.email = toLowerCaseSafe(email);
     }
 
     public String getFirstName() {
@@ -136,5 +136,9 @@ public class LegacyUser {
     public int hashCode() {
         return Objects.hash(id, username, email, firstName, lastName, isEnabled, isEmailVerified, attributes,
                 roles, groups, requiredActions);
+    }
+
+    public static String toLowerCaseSafe(String str) {
+        return str == null ? null : str.toLowerCase();
     }
 }

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserTest.java
@@ -14,7 +14,7 @@ class LegacyUserTest {
     @Test
     void shouldGetAndSetUsername() {
         var user = new LegacyUser();
-        var expectedValue = "someValue";
+        var expectedValue = "somevalue";
         user.setUsername(expectedValue);
         assertEquals(expectedValue, user.getUsername());
     }
@@ -22,7 +22,7 @@ class LegacyUserTest {
     @Test
     void shouldGetAndSetEmail() {
         var user = new LegacyUser();
-        var expectedValue = "someValue";
+        var expectedValue = "somevalue";
         user.setEmail(expectedValue);
         assertEquals(expectedValue, user.getEmail());
     }


### PR DESCRIPTION
adding support for incorrect api behaviour when the username and email has to be lowercase